### PR TITLE
Feature: Scaffold musl builds

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -10,7 +10,7 @@ env:
 on:
   push:
     branches:
-      - feat/musl
+      - master
     tags-ignore:
       - '**'
     paths:

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -10,7 +10,7 @@ env:
 on:
   push:
     branches:
-      - master
+      - feat/musl
     tags-ignore:
       - '**'
     paths:
@@ -80,17 +80,28 @@ jobs:
               yarn lerna exec "yarn build --target aarch64-unknown-linux-gnu" --concurrency 1 --stream --no-prefix
               llvm-strip ./*.node
 
-    #          - host: ubuntu-latest
-    #            target: 'x86_64-unknown-linux-musl'
-    #            build: |
-    #              cd bindings/nodejs &&
-    #              yarn build
-    #          - host: ubuntu-latest
-    #            target: 'aarch64-unknown-linux-musl'
-    #            build: >-
-    #              set -e &&
-    #              rustup target add aarch64-unknown-linux-musl &&
-    #              yarn lerna exec "yarn build --target aarch64-unknown-linux-musl" --concurrency 1 --stream --no-prefix
+          - host: ubuntu-latest
+            target: 'x86_64-unknown-linux-musl'
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+            build: |
+              set -e
+              cd bindings/nodejs
+              rustup target add x86_64-unknown-linux-musl
+              yarn lerna exec "yarn build --target x86_64-unknown-linux-musl" --concurrency 1 --stream --no-prefix
+              strip ./*.node
+
+          - host: ubuntu-latest
+            target: 'aarch64-unknown-linux-musl'
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+            build: |
+              set -e
+              cd bindings/nodejs
+              # Set environment variables for the Rust toolchain
+              export CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc
+              export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc
+              rustup target add aarch64-unknown-linux-musl
+              yarn lerna exec "yarn build --target aarch64-unknown-linux-musl" --concurrency 1 --stream --no-prefix
+              /aarch64-linux-musl-cross/bin/aarch64-linux-musl-strip *.node
 
     name: stable - ${{ matrix.settings.target }} - node@18
     runs-on: ${{ matrix.settings.host }}
@@ -257,7 +268,115 @@ jobs:
             yarn install
             yarn link
             yarn test
+  test-linux-x64-musl-binding:
+    name: Test bindings on Linux-x64-musl - node@${{ matrix.node }}
+    needs:
+      - build
+    defaults:
+      run:
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [ '16', '18', '20' ]
+    runs-on: ubuntu-latest
 
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          check-latest: true
+          cache: yarn
+          cache-dependency-path: 'bindings/nodejs/yarn.lock'
+
+      - name: Install dependencies
+        run: yarn install --immutable --mode=skip-build
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: bindings-x86_64-unknown-linux-musl
+          path: artifacts
+
+      - name: Move artifacts
+        run: yarn artifacts
+        shell: bash
+
+      - name: List folder
+        run: ls ./
+        shell: bash
+
+      - name: Test bindings
+        uses: addnab/docker-run-action@v3
+        with:
+          image: node:${{ matrix.node }}-alpine
+          options: -v ${{ github.workspace }}:/workspace
+          run: |
+            cd workspace/bindings/nodejs
+            yarn install
+            yarn link
+            yarn test
+  test-linux-aarch64-musl-binding:
+    name: Test bindings on Linux-aarch64-musl - node@${{ matrix.node }}
+    needs:
+      - build
+    defaults:
+      run:
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [ '16', '18', '20' ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          check-latest: true
+          cache: yarn
+          cache-dependency-path: 'bindings/nodejs/yarn.lock'
+
+      - name: Install dependencies
+        run: |
+          yarn config set supportedArchitectures.cpu "arm64"
+          yarn config set supportedArchitectures.libc "musl"
+          yarn install --immutable --mode=skip-build
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+      - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: bindings-aarch64-unknown-linux-musl
+          path: artifacts
+
+      - name: Move artifacts
+        run: yarn artifacts
+        shell: bash
+
+      - name: List folder
+        run: ls ./
+        shell: bash
+
+      - name: Test bindings
+        uses: addnab/docker-run-action@v3
+        with:
+          options: --platform linux/arm64 -v ${{ github.workspace }}:/workspace
+          image: node:${{ matrix.node }}-alpine
+          run: |
+            cd workspace/bindings/nodejs
+            yarn install
+            yarn link
+            yarn test
   #  test-linux-aarch64-gnu-binding:
   #    name: Test bindings on aarch64-unknown-linux-gnu - node@${{ matrix.node }}
   #    needs:
@@ -319,10 +438,11 @@ jobs:
     needs:
       - test-linux-x64-gnu-binding
       #      - test-linux-x64-centos-7
-      #      - test-linux-x64-musl-binding
+      - test-linux-x64-musl-binding
       #      - test-linux-aarch64-gnu-binding
       #      - test-linux-arm-gnueabihf-binding
       - test-macOS-windows-binding
+      - test-linux-aarch64-musl-binding
     steps:
       - uses: actions/checkout@v3
 

--- a/README.md
+++ b/README.md
@@ -324,8 +324,8 @@ maintainability in complex systems.
 | darwin-x64      | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | darwin-arm64    | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | win32-x64-msvc  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-
-We do not support linux-musl currently.
+| linux-x64-musl  | :x:                | :heavy_check_mark: | :x:                | :x:                |
+| linux-arm64-musl| :x:                | :heavy_check_mark: | :x:                | :x:                |
 
 ## Contribution
 

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -312,8 +312,8 @@ By incorporating the "Decision" node, developers can modularize decision logic, 
 | darwin-x64      | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | darwin-arm64    | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | win32-x64-msvc  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-
-We do not support linux-musl currently.
+| linux-x64-musl  | :x:                | :heavy_check_mark: | :x:                | :x:                |
+| linux-arm64-musl| :x:                | :heavy_check_mark: | :x:                | :x:                |
 
 ## Contribution
 

--- a/bindings/nodejs/npm/linux-arm64-musl/README.md
+++ b/bindings/nodejs/npm/linux-arm64-musl/README.md
@@ -1,0 +1,3 @@
+# `@gorules/zen-engine-linux-arm64-musl`
+
+This is the **aarch64-unknown-linux-musl** binary for `@gorules/zen-engine`

--- a/bindings/nodejs/npm/linux-arm64-musl/package.json
+++ b/bindings/nodejs/npm/linux-arm64-musl/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@gorules/zen-engine-linux-arm64-musl",
+  "version": "0.33.1",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "libc": [
+    "musl"
+  ],
+  "main": "zen-engine.linux-arm64-musl.node",
+  "files": [
+    "zen-engine.linux-arm64-musl.node"
+  ],
+  "description": "Rust zen-engine binding",
+  "keywords": [
+    "gorules",
+    "zen-engine",
+    "business rules engine",
+    "rules engine",
+    "rule engine",
+    "bre",
+    "rule",
+    "rules",
+    "engine",
+    "decision",
+    "decision table",
+    "rust",
+    "N-API",
+    "napi-rs",
+    "node-rs"
+  ],
+  "author": "GoRules <hi@gorules.io> (https://gorules.io)",
+  "homepage": "https://github.com/gorules/zen",
+  "license": "MIT",
+  "engines": {
+    "node": ">= 14"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gorules/zen.git"
+  },
+  "bugs": {
+    "url": "https://github.com/gorules/zen/issues"
+  }
+}

--- a/bindings/nodejs/npm/linux-x64-musl/README.md
+++ b/bindings/nodejs/npm/linux-x64-musl/README.md
@@ -1,0 +1,3 @@
+# `@gorules/zen-engine-linux-x64-musl`
+
+This is the **x86_64-unknown-linux-musl** binary for `@gorules/zen-engine`

--- a/bindings/nodejs/npm/linux-x64-musl/package.json
+++ b/bindings/nodejs/npm/linux-x64-musl/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@gorules/zen-engine-linux-x64-musl",
+  "version": "0.33.1",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "libc": [
+    "musl"
+  ],
+  "main": "zen-engine.linux-x64-musl.node",
+  "files": [
+    "zen-engine.linux-x64-musl.node"
+  ],
+  "description": "Rust zen-engine binding",
+  "keywords": [
+    "gorules",
+    "zen-engine",
+    "business rules engine",
+    "rules engine",
+    "rule engine",
+    "bre",
+    "rule",
+    "rules",
+    "engine",
+    "decision",
+    "decision table",
+    "rust",
+    "N-API",
+    "napi-rs",
+    "node-rs"
+  ],
+  "author": "GoRules <hi@gorules.io> (https://gorules.io)",
+  "homepage": "https://github.com/gorules/zen",
+  "license": "MIT",
+  "engines": {
+    "node": ">= 14"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gorules/zen.git"
+  },
+  "bugs": {
+    "url": "https://github.com/gorules/zen/issues"
+  }
+}

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -17,8 +17,10 @@
       "additional": [
         "x86_64-apple-darwin",
         "x86_64-unknown-linux-gnu",
+        "x86_64-unknown-linux-musl",
         "x86_64-pc-windows-msvc",
         "aarch64-unknown-linux-gnu",
+        "aarch64-unknown-linux-musl",
         "aarch64-apple-darwin"
       ]
     },


### PR DESCRIPTION
Hi there,

I am opening this as a Draft PR, in an attempt to get builds for `linux-musl` of the Zen Engine working for Node.js.